### PR TITLE
Remove multi-line strings for font stacks

### DIFF
--- a/includes/_typeface-vars.scss
+++ b/includes/_typeface-vars.scss
@@ -5,124 +5,31 @@
 
 
 // Serif 1
-$fontstack-georgia : "
-  Constantia, 
-  'Lucida Bright',
-  Lucidabright,
-  'Lucida Serif',
-  Lucida,
-  'DejaVu Serif',
-  Georgia,
-  'Palatino Linotype',
-  Palatino,
-  serif
-";
+$fontstack-georgia : "Constantia, 'Lucida Bright', Lucidabright, 'Lucida Serif', Lucida, 'DejaVu Serif', Georgia, 'Palatino Linotype', Palatino, serif";
 
 // Serif 2
-$fontstack-garamond : "
-  'Palatino Linotype', 
-  Palatino, 
-  Palladio, 
-  'URW Palladio L', 
-  'Book Antiqua', 
-  Baskerville, 
-  'Bookman Old Style', 
-  'Bitstream Charter', 
-  'Nimbus Roman No9 L', 
-  Garamond, 
-  'Apple Garamond', 
-  'ITC Garamond Narrow', 
-  'New Century Schoolbook', 
-  'Century Schoolbook', 
-  Georgia, 
-  serif
-";
+$fontstack-garamond : "Palatino Linotype', Palatino, Palladio, 'URW Palladio L', 'Book Antiqua', Baskerville, 'Bookman Old Style', 'Bitstream Charter', 'Nimbus Roman No9 L', Garamond, 'Apple Garamond', 'ITC Garamond Narrow', 'New Century Schoolbook', 'Century Schoolbook', Georgia, serif";
 
 // Serif 3 
-$fontstack-times : "
-  Cambria, 
-  'Hoefler Text', 
-  Utopia,
-  'Liberation Serif',
-  'Nimbus Roman No9 L Regular',
-  Times,
-  'Times New Roman',
-  serif;
-";
+$fontstack-times : "Cambria, 'Hoefler Text', Utopia,'Liberation Serif','Nimbus Roman No9 L Regular',Times,'Times New Roman',serif";
 
 
 // Sans-serif 1
-$fontstack-helvetica : "
-  Frutiger, 
-  'Frutiger Linotype', 
-  Univers, 
-  Calibri, 
-  'Gill Sans', 
-  'Gill Sans MT', 
-  'Myriad Pro', 
-  Myriad, 
-  'DejaVu Sans Condensed', 
-  'Liberation Sans', 
-  'Nimbus Sans L', 
-  Tahoma, 
-  Geneva, 
-  'Helvetica Neue', 
-  Helvetica, 
-  Arial, 
-  sans-serif
-";
+$fontstack-helvetica : "Frutiger, 'Frutiger Linotype', Univers, Calibri, 'Gill Sans', 'Gill Sans MT', 'Myriad Pro', Myriad, 'DejaVu Sans Condensed', 'Liberation Sans', 'Nimbus Sans L', Tahoma, Geneva, 'Helvetica Neue', Helvetica, Arial, sans-serif";
 
 // Sans-serif 2
-$fontstack-verdana : "
-  Corbel, 
-  'Lucida Grande', 
-  'Lucida Sans Unicode', 
-  'Lucida Sans', 
-  'DejaVu Sans', 
-  'Bitstream Vera Sans', 
-  'Liberation Sans', 
-  Verdana, 
-  'Verdana Ref', 
-  sans-serif
-";
+$fontstack-verdana : "Corbel, 'Lucida Grande', 'Lucida Sans Unicode', 'Lucida Sans', 'DejaVu Sans', 'Bitstream Vera Sans', 'Liberation Sans', Verdana, 'Verdana Ref', sans-serif";
 
 // Default Sans system font
-$fontstack-system : "
-  -apple-system, 
-  BlinkMacSystemFont, 
-  'Segoe UI', 
-  Roboto, 
-  Helvetica, 
-  Arial, 
-  sans-serif
-";
+$fontstack-system : "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif";
 
 
 // Monospaced (for code examples)
 
-$fontstack-mono-complex : "
-  'DejaVu sans mono', 
-  'Anonymous Pro', 
-  'Ubuntu Mono', 
-  'Droid Sans Mono Consolas', 
-  'Andale Mono', 
-  Consolas, 
-  Monaco, 
-  'Courier New', 
-  monospace
-";
+$fontstack-mono-complex : "'DejaVu sans mono', 'Anonymous Pro', 'Ubuntu Mono', 'Droid Sans Mono Consolas', 'Andale Mono', Consolas, Monaco, 'Courier New', monospace";
 
 
-$fontstack-mono-simple : "
-  Menlo, 
-  Inconsolata, 
-  Monaco, 
-  Consolas, 
-  'Courier New', 
-  'Ubuntu Mono',
-  Courier,
-  monospace 
-";
+$fontstack-mono-simple : "Menlo, Inconsolata, Monaco, Consolas, 'Courier New', 'Ubuntu Mono',Courier,monospace";
 
 // Font assignment
 // Level 2 


### PR DESCRIPTION
Multiline strings throw an error in recent versions of node-sass / dart-sass